### PR TITLE
chore: destroy marvin staging elasticache-memcached

### DIFF
--- a/aws_outshift-common-staging_us-east-2_elasticache_memcached-marvin-staging-use2-1_elasticache-memcached.tf
+++ b/aws_outshift-common-staging_us-east-2_elasticache_memcached-marvin-staging-use2-1_elasticache-memcached.tf
@@ -15,6 +15,7 @@ locals {
   eks_cluster_vpc_name = "marvin-stage-use2-1"
 }
 
+
 provider "aws" {
   access_key = data.vault_generic_secret.aws_infra_credential.data["AWS_ACCESS_KEY_ID"]
   secret_key = data.vault_generic_secret.aws_infra_credential.data["AWS_SECRET_ACCESS_KEY"]


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  
https://cisco-eti.atlassian.net/browse/SRE-9258

### Description/Justification

(Why is this change needed? Which team might need it? etc...)  


### If the (atlantis) plan is destroying resources, reason for deletion  


### Additional details

- [ ] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
