### PR TITLE
chore(auth): create Vault resources (k8s auth) for pyramid

### DIFF
--- a/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_eso-ventures_data.tf
+++ b/aws_outshift-common-dev_us-east-2_eks_comn-dev-use2-1_eso-ventures_data.tf
@@ -1,0 +1,18 @@
+data "vault_generic_secret" "aws_infra_credential" {
+  provider = vault.eticloud
+  path     = "secret/infra/aws/${local.aws_account_name}/terraform_admin"
+}
+
+data "vault_generic_secret" "cluster_certificate" {
+  provider = vault.eticloud
+  path     = "secret/infra/eks/${local.cluster_name}/certificate"
+}
+
+data "vault_generic_secret" "cluster_endpoint" {
+  provider = vault.eticloud
+  path     = "secret/infra/eks/${local.cluster_name}/cluster_endpoint"
+}
+
+data "aws_eks_cluster" "cluster" {
+  name = "comn-dev-use2-1"
+}


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  

Relates to https://github.com/cisco-eti/sre-baseapps-configs-common/pull/282, need Vault k8s auth resources to be created.
Removes the dependency to the EKS cluster itself so that we don't have to apply unrelated changes such as EKS nodegroup upgrade or add-ons upgrades.

### Description/Justification

(Why is this change needed? Which team might need it? etc...)  

https://cisco-eti.atlassian.net/jira/servicedesk/projects/OPENSD/section/service-requests/custom/59/OPENSD-1569

### If the (atlantis) plan is destroying resources, reason for deletion  


### Additional details

- [x] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
