### PR TITLE
fix: add putitem to zot dynamodb

### DIFF
--- a/aws_outshift-common-dev_iam_roles_phoenix_zot-s3-dynamo-role.tf
+++ b/aws_outshift-common-dev_iam_roles_phoenix_zot-s3-dynamo-role.tf
@@ -39,6 +39,7 @@ resource "aws_iam_policy" "zot_s3_dynamo_policy" {
         "Action" : [
           "dynamodb:GetItem",
           "dynamodb:UpdateItem",
+          "dynamodb:PutItem",
           "dynamodb:DeleteItem"
         ],
         "Resource" : "arn:aws:dynamodb:*:*:table/ZotBlobTable"


### PR DESCRIPTION
## Fixes/Implements # (JIRA issue if applicable)  


### Description/Justification

(Why is this change needed? Which team might need it? etc...)  


### If the (atlantis) plan is destroying resources, reason for deletion  


### Additional details

- [ ] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
