### PR TITLE
chore: apply IAMReadOnlyAccess permissions to ventures IAM roles

### DIFF
--- a/modules_sso-roles_main.tf
+++ b/modules_sso-roles_main.tf
@@ -11,3 +11,9 @@ resource "aws_iam_role_policy_attachment" "power_user_access_policy_attachment" 
   role       = aws_iam_role.this.name
   policy_arn = var.policy_arn
 }
+
+# Attach the IAMReadOnlyAccess AWS Managed policy
+resource "aws_iam_role_policy_attachment" "iam_read_only_policy_attachment" {
+  role       = aws_iam_role.this.name
+  policy_arn = var.iam_read_only_policy_arn
+}

--- a/modules_sso-roles_variables.tf
+++ b/modules_sso-roles_variables.tf
@@ -8,6 +8,13 @@ variable "policy_arn" {
   type        = string
   default = "arn:aws:iam::aws:policy/PowerUserAccess"
 }
+
+variable "iam_read_only_policy_arn" {
+  description = "ARN of the IAMReadOnlyAccess AWS managed policy to attach to the venture roles"
+  type        = string
+  default     = "arn:aws:iam::aws:policy/IAMReadOnlyAccess"
+}
+
 variable "tags" {
   description = "Tags to apply to the IAM roles"
   type        = map(string)


### PR DESCRIPTION
### Description/Justification
https://cisco-eti.atlassian.net/browse/SRE-9328  
Allow users connected with team based roles to list IAM Roles and Policies in common-dev account


### Additional details

- [x] `terraform fmt` was applied
- [ ] All atlantis plans can be applied
- [ ] (For reviewers) I have verified the resource changes
