### PR TITLE
Fixes #898: Replace hashicorp and terraform references

### DIFF
--- a/internal_command_e2etest_testdata_provider-not-found_main.tf
+++ b/internal_command_e2etest_testdata_provider-not-found_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     nonexist = {
-      source = "registry.opentofu.org/hashicorp/nonexist"
+      source = "registry.opentofu.org/opentofu/nonexist"
     }
   }
 }

--- a/internal_command_e2etest_testdata_provider-plugin_main.tf
+++ b/internal_command_e2etest_testdata_provider-plugin_main.tf
@@ -3,10 +3,10 @@
 terraform {
   required_providers {
     simple5 = {
-      source = "registry.opentofu.org/hashicorp/simple"
+      source = "registry.opentofu.org/opentofu/simple"
     }
     simple6 = {
-      source = "registry.opentofu.org/hashicorp/simple6"
+      source = "registry.opentofu.org/opentofu/simple6"
     }
   }
 }

--- a/internal_command_e2etest_testdata_provider-tampering-base_provider-tampering-base.tf
+++ b/internal_command_e2etest_testdata_provider-tampering-base_provider-tampering-base.tf
@@ -5,7 +5,7 @@ terraform {
       # test case here, though we might have to update this in future
       # if e.g. Terraform stops supporting plugin protocol 5, or if
       # the null provider is yanked from the registry for some reason.
-      source  = "hashicorp/null"
+      source  = "opentofu/null"
       version = "3.1.0"
     }
   }

--- a/internal_command_e2etest_testdata_provider-warnings_main.tf
+++ b/internal_command_e2etest_testdata_provider-warnings_main.tf
@@ -6,7 +6,7 @@ terraform {
             //
             // "This provider is archived and no longer needed. The terraform_remote_state
             // data source is built into the latest Terraform release."
-            source = "hashicorp/terraform"
+            source = "opentofu/terraform"
         }
     }
 }

--- a/internal_command_e2etest_testdata_test-provider_main.tf
+++ b/internal_command_e2etest_testdata_test-provider_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     simple = {
-      source = "hashicorp/test"
+      source = "opentofu/test"
     }
   }
 }

--- a/internal_command_e2etest_testdata_tofu-providers-mirror-with-lock-file_main.tf
+++ b/internal_command_e2etest_testdata_tofu-providers-mirror-with-lock-file_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
-    template  = { source = "hashicorp/template" }
-    null      = { source = "hashicorp/null" }
+    template  = { source = "opentofu/template" }
+    null      = { source = "opentofu/null" }
     terraform = { source = "terraform.io/builtin/terraform" }
   }
 }

--- a/internal_command_e2etest_testdata_tofu-providers-mirror_main.tf
+++ b/internal_command_e2etest_testdata_tofu-providers-mirror_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     template  = { version = "2.1.1" }
-    null      = { source = "hashicorp/null", version = "2.1.0" }
+    null      = { source = "opentofu/null", version = "2.1.0" }
     terraform = { source = "terraform.io/builtin/terraform" }
   }
 }

--- a/internal_command_e2etest_testdata_vendored-provider_main.tf
+++ b/internal_command_e2etest_testdata_vendored-provider_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     null = {
-      source  = "hashicorp/null"
+      source  = "opentofu/null"
       version = "1.0.0+local"
     }
   }

--- a/internal_command_testdata_init-with-tests-with-provider_main.tf
+++ b/internal_command_testdata_init-with-tests-with-provider_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     test = {
-      source = "hashicorp/test"
+      source = "opentofu/test"
       version = "1.0.2"
     }
   }

--- a/internal_command_testdata_init-with-tests-with-provider_setup_main.tf
+++ b/internal_command_testdata_init-with-tests-with-provider_setup_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     test = {
-      source = "hashicorp/test"
+      source = "opentofu/test"
       version = "1.0.1"
     }
   }

--- a/internal_command_testdata_providers-lock_append_main.tf
+++ b/internal_command_testdata_providers-lock_append_main.tf
@@ -1,7 +1,7 @@
 terraform {
     required_providers {
         test = {
-            source = "hashicorp/test"
+            source = "opentofu/test"
         }
     }
 }

--- a/internal_command_testdata_providers-lock_basic_main.tf
+++ b/internal_command_testdata_providers-lock_basic_main.tf
@@ -1,7 +1,7 @@
 terraform {
     required_providers {
         test = {
-            source = "hashicorp/test"
+            source = "opentofu/test"
         }
     }
 }

--- a/internal_command_testdata_providers-schema_required_provider.tf
+++ b/internal_command_testdata_providers-schema_required_provider.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     test = {
-      source = "hashicorp/test"
+      source = "opentofu/test"
     }
   }
 }

--- a/internal_command_testdata_show-json_provider-aliasing-conflict_child_main.tf
+++ b/internal_command_testdata_show-json_provider-aliasing-conflict_child_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     test = {
-      source = "hashicorp2/test"
+      source = "opentofu2/test"
     }
   }
 }

--- a/internal_command_testdata_show-json_provider-aliasing-default_child_main.tf
+++ b/internal_command_testdata_show-json_provider-aliasing-default_child_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     test = {
-      source = "hashicorp/test"
+      source = "opentofu/test"
     }
   }
 }

--- a/internal_command_testdata_show-json_provider-aliasing-default_child_nested_main.tf
+++ b/internal_command_testdata_show-json_provider-aliasing-default_child_nested_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     test = {
-      source = "hashicorp/test"
+      source = "opentofu/test"
     }
   }
 }

--- a/internal_command_testdata_show-json_provider-aliasing_child_main.tf
+++ b/internal_command_testdata_show-json_provider-aliasing_child_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     test = {
-      source                = "hashicorp/test"
+      source                = "opentofu/test"
       configuration_aliases = [test, test.second]
     }
   }

--- a/internal_command_testdata_show-json_provider-aliasing_child_nested_main.tf
+++ b/internal_command_testdata_show-json_provider-aliasing_child_nested_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     test = {
-      source                = "hashicorp/test"
+      source                = "opentofu/test"
       configuration_aliases = [test, test.alt]
     }
   }

--- a/internal_command_testdata_show-json_provider-version-no-config_main.tf
+++ b/internal_command_testdata_show-json_provider-version-no-config_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     test = {
-      source = "hashicorp/test"
+      source = "opentofu/test"
       version = ">= 1.2.3"
     }
   }

--- a/internal_command_testdata_show-json_provider-version_main.tf
+++ b/internal_command_testdata_show-json_provider-version_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     test = {
-      source = "hashicorp/test"
+      source = "opentofu/test"
       version = ">= 1.2.3"
     }
   }

--- a/internal_command_testdata_test_missing-provider-in-run-block_main.tf
+++ b/internal_command_testdata_test_missing-provider-in-run-block_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     test = {
-      source = "hashicorp/test"
+      source = "opentofu/test"
       configuration_aliases = [ test.secondary ]
     }
   }

--- a/internal_command_testdata_test_missing-provider-in-test-module_setup_main.tf
+++ b/internal_command_testdata_test_missing-provider-in-test-module_setup_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     test = {
-      source = "hashicorp/test"
+      source = "opentofu/test"
       configuration_aliases = [ test.secondary ]
     }
   }

--- a/internal_command_testdata_test_missing-provider_main.tf
+++ b/internal_command_testdata_test_missing-provider_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     test = {
-      source = "hashicorp/test"
+      source = "opentofu/test"
       configuration_aliases = [ test.secondary ]
     }
   }

--- a/internal_command_testdata_test_no_providers_in_main_main.tf
+++ b/internal_command_testdata_test_no_providers_in_main_main.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     test = {
-      source = "hashicorp/test"
+      source = "opentofu/test"
       configuration_aliases = [test.primary, test.secondary]
     }
   }

--- a/internal_configs_configload_testdata_add-version-constraint_add-version-constraint.tf
+++ b/internal_configs_configload_testdata_add-version-constraint_add-version-constraint.tf
@@ -5,6 +5,6 @@
 # registry does not need to be accessed when this test is successful.
 
 module "child" {
-  source  = "hashicorp/module-installer-acctest/aws"
+  source  = "opentofu/module-installer-acctest/aws"
   version = "0.0.1"
 }

--- a/internal_configs_configload_testdata_registry-modules_root.tf
+++ b/internal_configs_configload_testdata_registry-modules_root.tf
@@ -1,0 +1,33 @@
+# This fixture indirectly depends on a github repo at:
+#     https://github.com/hashicorp/terraform-aws-module-installer-acctest
+# ...and expects its v0.0.1 tag to be pointing at the following commit:
+#     d676ab2559d4e0621d59e3c3c4cbb33958ac4608
+#
+# This repository is accessed indirectly via:
+#     https://registry.terraform.io/modules/hashicorp/module-installer-acctest/aws/0.0.1
+#
+# Since the tag's id is included in a downloaded archive, it is expected to
+# have the following id:
+#     853d03855b3290a3ca491d4c3a7684572dd42237
+# (this particular assumption is encoded in the tests that use this fixture)
+
+
+variable "v" {
+  description = "in local caller for registry-modules"
+  default     = ""
+}
+
+module "acctest_root" {
+  source  = "opentofu/module-installer-acctest/aws"
+  version = "0.0.1"
+}
+
+module "acctest_child_a" {
+  source  = "opentofu/module-installer-acctest/aws//modules/child_a"
+  version = "0.0.1"
+}
+
+module "acctest_child_b" {
+  source  = "opentofu/module-installer-acctest/aws//modules/child_b"
+  version = "0.0.1"
+}

--- a/internal_configs_testdata_config-diagnostics_empty-configs_main.tf
+++ b/internal_configs_testdata_config-diagnostics_empty-configs_main.tf
@@ -1,10 +1,10 @@
 terraform {
   required_providers {
     foo = {
-      source = "hashicorp/foo"
+      source = "opentofu/foo"
     }
     baz = {
-      source = "hashicorp/baz"
+      source = "opentofu/baz"
     }
   }
 }

--- a/internal_configs_testdata_config-diagnostics_empty-configs_mod_main.tf
+++ b/internal_configs_testdata_config-diagnostics_empty-configs_mod_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     foo = {
-      source = "hashicorp/foo"
+      source = "opentofu/foo"
       configuration_aliases = [ foo.bar ]
     }
   }

--- a/internal_configs_testdata_config-diagnostics_incorrect-type_main.tf
+++ b/internal_configs_testdata_config-diagnostics_incorrect-type_main.tf
@@ -1,10 +1,10 @@
 terraform {
   required_providers {
     foo = {
-      source = "hashicorp/foo"
+      source = "opentofu/foo"
     }
     baz = {
-      source = "hashicorp/baz"
+      source = "opentofu/baz"
     }
   }
 }

--- a/internal_configs_testdata_config-diagnostics_pass-inherited-provider_mod2_main.tf
+++ b/internal_configs_testdata_config-diagnostics_pass-inherited-provider_mod2_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     test = {
-      source = "hashicorp/test"
+      source = "opentofu/test"
       configuration_aliases = [test.foo]
     }
   }

--- a/internal_configs_testdata_config-diagnostics_pass-inherited-provider_mod_main.tf
+++ b/internal_configs_testdata_config-diagnostics_pass-inherited-provider_mod_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     test = {
-      source = "hashicorp/test"
+      source = "opentofu/test"
     }
   }
 }

--- a/internal_configs_testdata_config-diagnostics_required-alias_mod_main.tf
+++ b/internal_configs_testdata_config-diagnostics_required-alias_mod_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     foo = {
-      source = "hashicorp/foo"
+      source = "opentofu/foo"
       version = "1.0.0"
       configuration_aliases = [ foo.bar ]
     }

--- a/internal_configs_testdata_config-diagnostics_tests-provider-mismatch-with-module_main.tf
+++ b/internal_configs_testdata_config-diagnostics_tests-provider-mismatch-with-module_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     foo = {
-      source = "hashicorp/foo"
+      source = "opentofu/foo"
       configuration_aliases = [foo.bar]
     }
   }

--- a/internal_configs_testdata_config-diagnostics_tests-provider-mismatch-with-module_setup_main.tf
+++ b/internal_configs_testdata_config-diagnostics_tests-provider-mismatch-with-module_setup_main.tf
@@ -1,11 +1,11 @@
 terraform {
     required_providers {
         foo = {
-            source = "hashicorp/bar"
+            source = "opentofu/bar"
             configuration_aliases = [ foo.bar ]
         }
         bar = {
-            source = "hashicorp/foo"
+            source = "opentofu/foo"
         }
     }
 }

--- a/internal_configs_testdata_config-diagnostics_tests-provider-mismatch_main.tf
+++ b/internal_configs_testdata_config-diagnostics_tests-provider-mismatch_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     foo = {
-      source = "hashicorp/foo"
+      source = "opentofu/foo"
       configuration_aliases = [foo.bar]
     }
   }

--- a/internal_configs_testdata_config-diagnostics_unexpected-provider_main.tf
+++ b/internal_configs_testdata_config-diagnostics_unexpected-provider_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     foo = {
-      source = "hashicorp/foo"
+      source = "opentofu/foo"
       version = "1.0.0"
     }
   }

--- a/internal_configs_testdata_config-diagnostics_with-depends-on_main.tf
+++ b/internal_configs_testdata_config-diagnostics_with-depends-on_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     foo = {
-      source = "hashicorp/foo"
+      source = "opentofu/foo"
     }
   }
 }

--- a/internal_configs_testdata_config-diagnostics_with-depends-on_mod1_main.tf
+++ b/internal_configs_testdata_config-diagnostics_with-depends-on_mod1_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     foo = {
-      source = "hashicorp/foo"
+      source = "opentofu/foo"
     }
   }
 }

--- a/internal_configs_testdata_config-diagnostics_with-depends-on_mod1_mod2_main.tf
+++ b/internal_configs_testdata_config-diagnostics_with-depends-on_mod1_mod2_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     foo = {
-      source = "hashicorp/foo"
+      source = "opentofu/foo"
     }
   }
 }

--- a/internal_configs_testdata_config-diagnostics_with-depends-on_mod1_mod2_mod3_main.tf
+++ b/internal_configs_testdata_config-diagnostics_with-depends-on_mod1_mod2_mod3_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     foo = {
-      source = "hashicorp/foo"
+      source = "opentofu/foo"
       configuration_aliases = [ foo.bar ]
     }
   }

--- a/internal_configs_testdata_duplicate-local-name_main.tf
+++ b/internal_configs_testdata_duplicate-local-name_main.tf
@@ -1,17 +1,17 @@
 terraform {
   required_providers {
     test = {
-      source = "hashicorp/test"
+      source = "opentofu/test"
     }
     dupe = {
-      source = "hashicorp/test"
+      source = "opentofu/test"
     }
     other = {
-      source = "hashicorp/default"
+      source = "opentofu/default"
     }
 
     wrong-name = {
-      source = "hashicorp/foo"
+      source = "opentofu/foo"
     }
   }
 }

--- a/internal_configs_testdata_invalid-files_module-calls.tf
+++ b/internal_configs_testdata_invalid-files_module-calls.tf
@@ -5,7 +5,7 @@ module "foo" {
 }
 
 module "bar" {
-  source = "hashicorp/bar/aws"
+  source = "opentofu/bar/aws"
 
   boom = "🎆"
   yes  = true

--- a/internal_configs_testdata_invalid-files_provider-localname-normalization.tf
+++ b/internal_configs_testdata_invalid-files_provider-localname-normalization.tf
@@ -15,6 +15,6 @@ resource test_resource "test" {
 }
 
 resource test_resource "TEST" {
-  // this resource is (explicitly) provided by "hashicorp/test"
+  // this resource is (explicitly) provided by "opentofu/test"
   provider = TEST
 }

--- a/internal_configs_testdata_provider-reqs-with-tests_provider-reqs-root.tf
+++ b/internal_configs_testdata_provider-reqs-with-tests_provider-reqs-root.tf
@@ -1,20 +1,20 @@
 terraform {
   required_providers {
     tls = {
-      source  = "hashicorp/tls"
+      source  = "opentofu/tls"
       version = "~> 3.0"
     }
   }
 }
 
 # There is no provider in required_providers called "implied", so this
-# implicitly declares a dependency on "hashicorp/implied".
+# implicitly declares a dependency on "opentofu/implied".
 resource "implied_foo" "bar" {
 }
 
 # There is no provider in required_providers called "terraform", but for
 # this name in particular we imply terraform.io/builtin/terraform instead,
 # to avoid selecting the now-unmaintained
-# registry.opentofu.org/hashicorp/terraform.
+# registry.opentofu.org/opentofu/terraform.
 data "terraform_remote_state" "bar" {
 }

--- a/internal_configs_testdata_provider-reqs_child_grandchild_provider-reqs-grandchild.tf
+++ b/internal_configs_testdata_provider-reqs_child_grandchild_provider-reqs-grandchild.tf
@@ -1,4 +1,4 @@
 # There is no provider in required_providers called "grandchild", so this
-# implicitly declares a dependency on "hashicorp/grandchild".
+# implicitly declares a dependency on "opentofu/grandchild".
 resource "grandchild_foo" "bar" {
 }

--- a/internal_configs_testdata_provider-reqs_provider-reqs-root.tf
+++ b/internal_configs_testdata_provider-reqs_provider-reqs-root.tf
@@ -5,14 +5,14 @@ terraform {
       version = "~> 1.2.0"
     }
     tls = {
-      source  = "hashicorp/tls"
+      source  = "opentofu/tls"
       version = "~> 3.0"
     }
   }
 }
 
 # There is no provider in required_providers called "implied", so this
-# implicitly declares a dependency on "hashicorp/implied".
+# implicitly declares a dependency on "opentofu/implied".
 resource "implied_foo" "bar" {
 }
 
@@ -23,7 +23,7 @@ module "kinder" {
 # There is no provider in required_providers called "terraform", but for
 # this name in particular we imply terraform.io/builtin/terraform instead,
 # to avoid selecting the now-unmaintained
-# registry.opentofu.org/hashicorp/terraform.
+# registry.opentofu.org/opentofu/terraform.
 data "terraform_remote_state" "bar" {
 }
 

--- a/internal_configs_testdata_valid-files_providers-explicit-implied.tf
+++ b/internal_configs_testdata_valid-files_providers-explicit-implied.tf
@@ -28,7 +28,7 @@ import {
 terraform {
   required_providers {
     test = {
-      source = "hashicorp/test"
+      source = "opentofu/test"
     }
   }
 }

--- a/internal_configs_testdata_valid-modules_implied-providers_resources.tf
+++ b/internal_configs_testdata_valid-modules_implied-providers_resources.tf
@@ -2,7 +2,7 @@
 resource foo_resource "a" {}
 data foo_resource "b" {}
 
-// These resources map to a default "hashicorp/bar" provider
+// These resources map to a default "opentofu/bar" provider
 resource bar_resource "c" {}
 data bar_resource "d" {}
 

--- a/internal_configs_testdata_valid-modules_importable-resource_providers.tf
+++ b/internal_configs_testdata_valid-modules_importable-resource_providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     local = {
-      source = "hashicorp/local"
+      source = "opentofu/local"
     }
   }
 }

--- a/internal_configs_testdata_valid-modules_override-resource-provider_base.tf
+++ b/internal_configs_testdata_valid-modules_override-resource-provider_base.tf
@@ -13,5 +13,5 @@ resource "test_instance" "explicit" {
   provider = foo-test
 }
 
-// the provider for this resource should default to "hashicorp/test"
+// the provider for this resource should default to "opentofu/test"
 resource "test_instance" "default" {}

--- a/internal_initwd_testdata_local-module-missing-provider_main.tf
+++ b/internal_initwd_testdata_local-module-missing-provider_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     foo = {
-      source = "hashicorp/foo"
+      source = "opentofu/foo"
       // since this module declares an alias with no config, it is not valid as
       // a root module.
       configuration_aliases = [ foo.alternate ]

--- a/internal_initwd_testdata_prerelease-version-constraint-match_root.tf
+++ b/internal_initwd_testdata_prerelease-version-constraint-match_root.tf
@@ -1,0 +1,7 @@
+# We expect this test to download the requested version because it is an exact
+# match for a prerelease version.
+
+module "acctest_exact" {
+  source = "opentofu/module-installer-acctest/aws"
+  version = "=0.0.3-alpha.1"
+}

--- a/internal_initwd_testdata_prerelease-version-constraint_root.tf
+++ b/internal_initwd_testdata_prerelease-version-constraint_root.tf
@@ -3,6 +3,6 @@
 # prerelease.
 
 module "acctest_partial" {
-  source = "hashicorp/module-installer-acctest/aws"
+  source = "opentofu/module-installer-acctest/aws"
   version = "<=0.0.3-alpha.1"
 }

--- a/internal_initwd_testdata_registry-modules_root.tf
+++ b/internal_initwd_testdata_registry-modules_root.tf
@@ -1,0 +1,33 @@
+# This fixture indirectly depends on a github repo at:
+#     https://github.com/hashicorp/terraform-aws-module-installer-acctest
+# ...and expects its v0.0.1 tag to be pointing at the following commit:
+#     d676ab2559d4e0621d59e3c3c4cbb33958ac4608
+#
+# This repository is accessed indirectly via:
+#     https://registry.terraform.io/modules/hashicorp/module-installer-acctest/aws/0.0.1
+#
+# Since the tag's id is included in a downloaded archive, it is expected to
+# have the following id:
+#     853d03855b3290a3ca491d4c3a7684572dd42237
+# (this particular assumption is encoded in the tests that use this fixture)
+
+
+variable "v" {
+  description = "in local caller for registry-modules"
+  default     = ""
+}
+
+module "acctest_root" {
+  source  = "opentofu/module-installer-acctest/aws"
+  version = "0.0.1"
+}
+
+module "acctest_child_a" {
+  source  = "opentofu/module-installer-acctest/aws//modules/child_a"
+  version = "0.0.1"
+}
+
+module "acctest_child_b" {
+  source  = "opentofu/module-installer-acctest/aws//modules/child_b"
+  version = "0.0.1"
+}

--- a/internal_tofu_testdata_transform-provider-fqns-module_child_main.tf
+++ b/internal_tofu_testdata_transform-provider-fqns-module_child_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     your-aws = {
-      source = "hashicorp/aws"
+      source = "opentofu/aws"
     }
   }
 }

--- a/internal_tofu_testdata_transform-provider-fqns-module_main.tf
+++ b/internal_tofu_testdata_transform-provider-fqns-module_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     my-aws = {
-      source = "hashicorp/aws"
+      source = "opentofu/aws"
     }
   }
 }

--- a/internal_tofu_testdata_transform-provider-fqns_main.tf
+++ b/internal_tofu_testdata_transform-provider-fqns_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     my-aws = {
-      source = "hashicorp/aws"
+      source = "opentofu/aws"
     }
   }
 }

--- a/internal_tofu_testdata_validate-required-provider-config_main.tf
+++ b/internal_tofu_testdata_validate-required-provider-config_main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     arbitrary = {
-      source = "hashicorp/aws"
+      source = "opentofu/aws"
     }
   }
 }

--- a/testing_equivalence-tests_tests_basic_json_string_update_main.tf
+++ b/testing_equivalence-tests_tests_basic_json_string_update_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_basic_list_empty_main.tf
+++ b/testing_equivalence-tests_tests_basic_list_empty_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_basic_list_main.tf
+++ b/testing_equivalence-tests_tests_basic_list_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_basic_list_null_main.tf
+++ b/testing_equivalence-tests_tests_basic_list_null_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_basic_list_update_main.tf
+++ b/testing_equivalence-tests_tests_basic_list_update_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_basic_map_empty_main.tf
+++ b/testing_equivalence-tests_tests_basic_map_empty_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_basic_map_main.tf
+++ b/testing_equivalence-tests_tests_basic_map_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_basic_map_null_main.tf
+++ b/testing_equivalence-tests_tests_basic_map_null_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_basic_map_update_main.tf
+++ b/testing_equivalence-tests_tests_basic_map_update_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_basic_multiline_string_update_main.tf
+++ b/testing_equivalence-tests_tests_basic_multiline_string_update_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_basic_set_empty_main.tf
+++ b/testing_equivalence-tests_tests_basic_set_empty_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_basic_set_main.tf
+++ b/testing_equivalence-tests_tests_basic_set_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_basic_set_null_main.tf
+++ b/testing_equivalence-tests_tests_basic_set_null_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_basic_set_update_main.tf
+++ b/testing_equivalence-tests_tests_basic_set_update_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_data_read_main.tf
+++ b/testing_equivalence-tests_tests_data_read_main.tf
@@ -1,15 +1,15 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
     local = {
-      source  = "hashicorp/local"
+      source  = "opentofu/local"
       version = "2.2.3"
     }
     random = {
-      source = "hashicorp/random"
+      source = "opentofu/random"
       version = "3.4.3"
     }
   }

--- a/testing_equivalence-tests_tests_drift_refresh_only_main.tf
+++ b/testing_equivalence-tests_tests_drift_refresh_only_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_drift_relevant_attributes_main.tf
+++ b/testing_equivalence-tests_tests_drift_relevant_attributes_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_drift_simple_main.tf
+++ b/testing_equivalence-tests_tests_drift_simple_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_fully_populated_complex_destroy_main.tf
+++ b/testing_equivalence-tests_tests_fully_populated_complex_destroy_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_fully_populated_complex_main.tf
+++ b/testing_equivalence-tests_tests_fully_populated_complex_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_fully_populated_complex_update_main.tf
+++ b/testing_equivalence-tests_tests_fully_populated_complex_update_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_local_provider_basic_main.tf
+++ b/testing_equivalence-tests_tests_local_provider_basic_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     local = {
-      source  = "hashicorp/local"
+      source  = "opentofu/local"
       version = "2.2.3"
     }
   }

--- a/testing_equivalence-tests_tests_local_provider_delete_main.tf
+++ b/testing_equivalence-tests_tests_local_provider_delete_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     local = {
-      source  = "hashicorp/local"
+      source  = "opentofu/local"
       version = "2.2.3"
     }
   }

--- a/testing_equivalence-tests_tests_local_provider_update_main.tf
+++ b/testing_equivalence-tests_tests_local_provider_update_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     local = {
-      source  = "hashicorp/local"
+      source  = "opentofu/local"
       version = "2.2.3"
     }
   }

--- a/testing_equivalence-tests_tests_moved_simple_main.tf
+++ b/testing_equivalence-tests_tests_moved_simple_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_moved_with_drift_main.tf
+++ b/testing_equivalence-tests_tests_moved_with_drift_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_moved_with_refresh_only_main.tf
+++ b/testing_equivalence-tests_tests_moved_with_refresh_only_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_moved_with_update_main.tf
+++ b/testing_equivalence-tests_tests_moved_with_update_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_multiple_block_types_main.tf
+++ b/testing_equivalence-tests_tests_multiple_block_types_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_multiple_block_types_update_main.tf
+++ b/testing_equivalence-tests_tests_multiple_block_types_update_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_nested_list_main.tf
+++ b/testing_equivalence-tests_tests_nested_list_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_nested_list_update_main.tf
+++ b/testing_equivalence-tests_tests_nested_list_update_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_nested_map_main.tf
+++ b/testing_equivalence-tests_tests_nested_map_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source = "hashicorp/tfcoremock"
+      source = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_nested_map_update_main.tf
+++ b/testing_equivalence-tests_tests_nested_map_update_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source = "hashicorp/tfcoremock"
+      source = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_nested_objects_main.tf
+++ b/testing_equivalence-tests_tests_nested_objects_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source = "hashicorp/tfcoremock"
+      source = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_nested_objects_update_main.tf
+++ b/testing_equivalence-tests_tests_nested_objects_update_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source = "hashicorp/tfcoremock"
+      source = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_nested_set_main.tf
+++ b/testing_equivalence-tests_tests_nested_set_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source = "hashicorp/tfcoremock"
+      source = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_nested_set_update_main.tf
+++ b/testing_equivalence-tests_tests_nested_set_update_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source = "hashicorp/tfcoremock"
+      source = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_null_provider_delete_main.tf
+++ b/testing_equivalence-tests_tests_null_provider_delete_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     null = {
-      source  = "hashicorp/null"
+      source  = "opentofu/null"
       version = "3.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_replace_within_list_main.tf
+++ b/testing_equivalence-tests_tests_replace_within_list_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_replace_within_map_main.tf
+++ b/testing_equivalence-tests_tests_replace_within_map_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_replace_within_object_main.tf
+++ b/testing_equivalence-tests_tests_replace_within_object_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_replace_within_set_main.tf
+++ b/testing_equivalence-tests_tests_replace_within_set_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_simple_object_empty_main.tf
+++ b/testing_equivalence-tests_tests_simple_object_empty_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_simple_object_main.tf
+++ b/testing_equivalence-tests_tests_simple_object_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_simple_object_null_main.tf
+++ b/testing_equivalence-tests_tests_simple_object_null_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_simple_object_replace_main.tf
+++ b/testing_equivalence-tests_tests_simple_object_replace_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }

--- a/testing_equivalence-tests_tests_simple_object_update_main.tf
+++ b/testing_equivalence-tests_tests_simple_object_update_main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     tfcoremock = {
-      source  = "hashicorp/tfcoremock"
+      source  = "opentofu/tfcoremock"
       version = "0.1.1"
     }
   }


### PR DESCRIPTION
This PR replaces most references to Hashicorp and Terraform with OpenTofu where relevant.

Resolves #898

## Target Release

1.6.0

## Current status

Most of the tests pass, however the following tests don't and need to be fixed.

### `github.com/opentofu/opentofu/internal/backend/remote`

- [x] `TestRemote_config`
- [x] `TestRemote_VerifyWorkspaceTerraformVersion_ignoreFlagSet`
- [x] `TestRemote_ServiceDiscoveryAliases`

### `github.com/opentofu/opentofu/internal/cloud`

- [x] `TestCloud_setUnavailableTerraformVersion`
- [x] `TestCloud_localBackend`
- [x] `TestCloud_addAndRemoveWorkspacesDefault`
- [x] `TestCloud_StateMgr_versionCheck`
- [x] `TestCloud_StateMgr_versionCheckLatest`
- [x] `TestCloud_VerifyWorkspaceTerraformVersion`
- [x] `TestCloud_VerifyWorkspaceTerraformVersion_workspaceErrors`
- [x] `TestCloud_VerifyWorkspaceTerraformVersion_ignoreFlagSet`
- [x] `TestCloudBackend_DeleteWorkspace_SafeAndForce`
- [x] `TestCloudBackend_DeleteWorkspace_DoesNotExist`
- [x] `TestCloud_ServiceDiscoveryAliases`
- [x] `TestState_GetRootOutputValues`
- [x] `TestState`
- [x] `TestCloudLocks`
- [x] `TestDelete_SafeDeleteNotSupported`
- [x] `TestDelete_ForceDelete`
- [x] `TestDelete_SafeDelete`
- [x] `TestState_PersistState`
- [x] `TestState_ShouldPersistIntermediateState`

### `github.com/opentofu/internal/command`

- [x] `TestInit_providerSource`
- [x] `TestInit_getUpgradePlugins`
- [x] `TestInit_providerLockFile`
- [x] `TestInit_providerLockFileReadonly`
- [x] `TestInit_pluginDirProviders`
- [x] `TestInit_testsWithProvider`
- [x] `TestProvidersLock`
- [x] `TestTest_ValidatesBeforeExecution`

### `github.com/opentofu/opentofu/internal/configs`

- [x] `TestBuildConfigInvalidModules`
- [x] `TestLoadModuleCall`

### `github.com/opentofu/opentofu/internal/getproviders`

- [x] `TestFilesystemMirrorSourceAllAvailablePackages`
- [x] `TestFilesystemMirrorSourceAvailableVersions`
- [x] `TestFilesystemMirrorSourcePackageMeta`
- [x] `TestMultiSourceSelector`
- [x] `TestPackageHashAuthentication_success`
- [x] `TestPackageHashAuthentication_failure`
- [x] `TestArchiveChecksumAuthentication_success`
- [x] `TestArchiveChecksumAuthentication_failure`

### `github.com/opentofu/opentofu/internal/providercache`

- [x] `TestCachedProviderHash`
- [x] `TestExecutableFile`
- [x] `TestLinkFromOtherCache`
- [x] `TestDirReading`
- [x] `TestEnsureProviderVersions_local_source`